### PR TITLE
Fallback to GitHub if jenkins job build info does not contain repos/commits

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,6 @@
 -e file:.#egg=jenkins_to_github_notify
 fastapi
+github3.py
 mypy
 pre-commit
 pytest-mock

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,8 @@ attrs==21.4.0
     # via pytest
 certifi==2022.6.15
     # via requests
+cffi==1.15.1
+    # via cryptography
 cfgv==3.3.1
     # via pre-commit
 charset-normalizer==2.1.0
@@ -24,12 +26,16 @@ colorama==0.4.5
     # via
     #   click
     #   pytest
+cryptography==37.0.4
+    # via pyjwt
 distlib==0.3.5
     # via virtualenv
 fastapi==0.79.0
     # via -r requirements.in
 filelock==3.7.1
     # via virtualenv
+github3-py==3.2.0
+    # via -r requirements.in
 h11==0.13.0
     # via uvicorn
 identify==2.5.2
@@ -60,8 +66,12 @@ pre-commit==2.20.0
     # via -r requirements.in
 py==1.11.0
     # via pytest
+pycparser==2.21
+    # via cffi
 pydantic==1.9.1
     # via fastapi
+pyjwt[crypto]==2.4.0
+    # via github3-py
 pyparsing==3.0.9
     # via packaging
 pytest==7.1.2
@@ -75,6 +85,8 @@ pytest-mock==3.8.2
     # via -r requirements.in
 pytest-regressions==2.3.1
     # via -r requirements.in
+python-dateutil==2.8.2
+    # via github3-py
 python-dotenv==0.20.0
     # via -r requirements.in
 python-jenkins==1.7.0
@@ -84,9 +96,12 @@ pyyaml==6.0
     #   pre-commit
     #   pytest-regressions
 requests==2.28.1
-    # via python-jenkins
+    # via
+    #   github3-py
+    #   python-jenkins
 six==1.16.0
     # via
+    #   python-dateutil
     #   python-jenkins
     #   virtualenv
 sniffio==1.2.0
@@ -103,6 +118,8 @@ typing-extensions==4.3.0
     # via
     #   mypy
     #   pydantic
+uritemplate==4.1.1
+    # via github3-py
 urllib3==1.26.10
     # via requests
 uvicorn==0.18.2

--- a/src/jenkins_to_github_notify/app.py
+++ b/src/jenkins_to_github_notify/app.py
@@ -26,7 +26,7 @@ async def startup_event() -> None:
         assert isinstance(value, str), f"Unexpected type in config value: {value!r} {type(value)}"
         config[key] = value
     check_configuration(config)
-    logging.basicConfig(level=logging.INFO, format="%(levelname)-8s  %(message)s")
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s]  %(message)-8s")
     logger.setLevel(logging.INFO)
     logger.info("Configuration validated.")
 

--- a/tests/test_jenkins_to_github_notify/jenkins-response-no-build-data.json
+++ b/tests/test_jenkins_to_github_notify/jenkins-response-no-build-data.json
@@ -1,0 +1,58 @@
+{
+  "_class" : "hudson.model.FreeStyleBuild",
+  "actions" : [
+    {
+      "_class" : "hudson.model.CauseAction",
+      "causes" : [
+        {
+          "_class" : "hudson.model.Cause$UserIdCause",
+          "shortDescription" : "Started by user Bruno Oliveira",
+          "userId" : "bruno",
+          "userName" : "Bruno Oliveira"
+        }
+      ]
+    },
+    {
+
+    },
+    {
+
+    },
+    {
+
+    },
+    {
+      "_class" : "org.jenkinsci.plugins.displayurlapi.actions.RunDisplayAction"
+    }
+  ],
+  "artifacts" : [
+
+  ],
+  "building" : true,
+  "description" : null,
+  "displayName" : "#16",
+  "duration" : 0,
+  "estimatedDuration" : 71716,
+  "executor" : {
+
+  },
+  "fullDisplayName" : "test-code-cov-fb-EDEN-2506-github-notification-newlinux #16",
+  "id" : "16",
+  "keepLog" : false,
+  "number" : 16,
+  "queueId" : 112984,
+  "result" : null,
+  "timestamp" : 1658510177623,
+  "url" : "https://eden.esss.co/jenkins/job/test-code-cov-fb-EDEN-2506-github-notification-newlinux/16/",
+  "builtOn" : "dev-centos7-linux-sv02-ci03",
+  "changeSet" : {
+    "_class" : "hudson.scm.EmptyChangeLogSet",
+    "items" : [
+
+    ],
+    "kind" : null
+  },
+  "culprits" : [
+
+  ]
+}

--- a/tests/test_jenkins_to_github_notify/job-multiple-repos.xml
+++ b/tests/test_jenkins_to_github_notify/job-multiple-repos.xml
@@ -1,0 +1,224 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?><project>
+  <actions/>
+  <description>&lt;!-- Managed by Job's Done --&gt;</description>
+  <keepDependencies>false</keepDependencies>
+  <properties>
+    <jenkins.model.BuildDiscarderProperty>
+      <strategy class="hudson.tasks.LogRotator">
+        <daysToKeep>7</daysToKeep>
+        <numToKeep>-1</numToKeep>
+        <artifactDaysToKeep>-1</artifactDaysToKeep>
+        <artifactNumToKeep>-1</artifactNumToKeep>
+      </strategy>
+    </jenkins.model.BuildDiscarderProperty>
+    <com.dabsquared.gitlabjenkins.connection.GitLabConnectionProperty plugin="gitlab-plugin@1.5.35">
+      <gitLabConnection>gitlab-esss</gitLabConnection>
+      <jobCredentialId/>
+      <useAlternativeCredential>false</useAlternativeCredential>
+    </com.dabsquared.gitlabjenkins.connection.GitLabConnectionProperty>
+
+  </properties>
+  <scm class="org.jenkinsci.plugins.multiplescms.MultiSCM" plugin="multiple-scms@0.8">
+    <scms>
+      <hudson.plugins.git.GitSCM plugin="git@4.11.3">
+        <configVersion>2</configVersion>
+        <userRemoteConfigs>
+          <hudson.plugins.git.UserRemoteConfig>
+            <url>git@github.com:ESSS/test-code-cov.git</url>
+          </hudson.plugins.git.UserRemoteConfig>
+        </userRemoteConfigs>
+        <branches>
+          <hudson.plugins.git.BranchSpec>
+            <name>fb-EDEN-2506-github-notification</name>
+          </hudson.plugins.git.BranchSpec>
+        </branches>
+        <doGenerateSubmoduleConfigurations>false</doGenerateSubmoduleConfigurations>
+        <submoduleCfg class="empty-list"/>
+        <extensions>
+          <hudson.plugins.git.extensions.impl.LocalBranch>
+            <localBranch>fb-EDEN-2506-github-notification</localBranch>
+          </hudson.plugins.git.extensions.impl.LocalBranch>
+          <hudson.plugins.git.extensions.impl.CloneOption>
+            <shallow>false</shallow>
+            <noTags>true</noTags>
+            <reference>$WORKSPACE/../../Shared/ref_repos/github/alfasim</reference>
+            <honorRefspec>false</honorRefspec>
+          </hudson.plugins.git.extensions.impl.CloneOption>
+          <hudson.plugins.git.extensions.impl.CleanCheckout>
+            <deleteUntrackedNestedRepositories>false</deleteUntrackedNestedRepositories>
+          </hudson.plugins.git.extensions.impl.CleanCheckout>
+          <hudson.plugins.git.extensions.impl.GitLFSPull/>
+          <hudson.plugins.git.extensions.impl.RelativeTargetDirectory>
+            <relativeTargetDir>test-code-cov</relativeTargetDir>
+          </hudson.plugins.git.extensions.impl.RelativeTargetDirectory>
+        </extensions>
+      </hudson.plugins.git.GitSCM>
+      <hudson.plugins.git.GitSCM plugin="git@4.11.3">
+        <configVersion>2</configVersion>
+        <userRemoteConfigs>
+          <hudson.plugins.git.UserRemoteConfig>
+            <url>ssh://git@eden.fln.esss.com.br:7999/esss/eden.git</url>
+          </hudson.plugins.git.UserRemoteConfig>
+        </userRemoteConfigs>
+        <branches>
+          <hudson.plugins.git.BranchSpec>
+            <name>fb-EDEN-2506-github-notification</name>
+          </hudson.plugins.git.BranchSpec>
+        </branches>
+        <doGenerateSubmoduleConfigurations>false</doGenerateSubmoduleConfigurations>
+        <submoduleCfg class="empty-list"/>
+        <extensions>
+          <hudson.plugins.git.extensions.impl.LocalBranch>
+            <localBranch>fb-EDEN-2506-github-notification</localBranch>
+          </hudson.plugins.git.extensions.impl.LocalBranch>
+          <hudson.plugins.git.extensions.impl.CloneOption>
+            <shallow>false</shallow>
+            <noTags>true</noTags>
+            <reference>$WORKSPACE/../../Shared/ref_repos/eden</reference>
+            <honorRefspec>false</honorRefspec>
+          </hudson.plugins.git.extensions.impl.CloneOption>
+          <hudson.plugins.git.extensions.impl.CleanCheckout>
+            <deleteUntrackedNestedRepositories>false</deleteUntrackedNestedRepositories>
+          </hudson.plugins.git.extensions.impl.CleanCheckout>
+          <hudson.plugins.git.extensions.impl.GitLFSPull/>
+          <hudson.plugins.git.extensions.impl.RelativeTargetDirectory>
+            <relativeTargetDir>eden</relativeTargetDir>
+          </hudson.plugins.git.extensions.impl.RelativeTargetDirectory>
+        </extensions>
+      </hudson.plugins.git.GitSCM>
+    </scms>
+  </scm>
+  <assignedNode>newlinux</assignedNode>
+  <canRoam>false</canRoam>
+  <disabled>false</disabled>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <triggers/>
+  <concurrentBuild>false</concurrentBuild>
+  <builders>
+    <hudson.tasks.Shell>
+      <command>bash -exc "
+    export CONDA_PY=36
+    export ESSS_SINGLE_ENV=1
+    cd $WORKSPACE/test-code-cov
+    source $WORKSPACE/eden/bin/setup_slave
+    echo Hello world
+"</command>
+      <configuredLocalRules/>
+    </hudson.tasks.Shell>
+    <org.jenkinsci.plugins.conditionalbuildstep.singlestep.SingleConditionalBuilder plugin="conditional-buildstep@1.4.2">
+      <condition class="org.jenkins_ci.plugins.run_condition.core.StatusCondition" plugin="run-condition@1.5">
+        <worstResult>
+          <name>SUCCESS</name>
+          <ordinal>0</ordinal>
+          <color>BLUE</color>
+          <completeBuild>true</completeBuild>
+        </worstResult>
+        <bestResult>
+          <name>SUCCESS</name>
+          <ordinal>0</ordinal>
+          <color>BLUE</color>
+          <completeBuild>true</completeBuild>
+        </bestResult>
+      </condition>
+      <buildStep class="hudson.tasks.Shell">
+        <command>export CONDA_PY=36
+cd $WORKSPACE/test-code-cov
+$WORKSPACE/eden/bin/exenv python $WORKSPACE/eden/bin/notify-github-commit-status.py success</command>
+        <configuredLocalRules/>
+      </buildStep>
+      <runner class="org.jenkins_ci.plugins.run_condition.BuildStepRunner$Fail" plugin="run-condition@1.5"/>
+    </org.jenkinsci.plugins.conditionalbuildstep.singlestep.SingleConditionalBuilder>
+    <org.jenkinsci.plugins.conditionalbuildstep.singlestep.SingleConditionalBuilder plugin="conditional-buildstep@1.4.2">
+      <condition class="org.jenkins_ci.plugins.run_condition.core.StatusCondition" plugin="run-condition@1.5">
+        <worstResult>
+          <name>ABORTED</name>
+          <ordinal>4</ordinal>
+          <color>ABORTED</color>
+          <completeBuild>false</completeBuild>
+        </worstResult>
+        <bestResult>
+          <name>UNSTABLE</name>
+          <ordinal>1</ordinal>
+          <color>YELLOW</color>
+          <completeBuild>true</completeBuild>
+        </bestResult>
+      </condition>
+      <buildStep class="hudson.tasks.Shell">
+        <command>export CONDA_PY=36
+cd $WORKSPACE/test-code-cov
+$WORKSPACE/eden/bin/exenv python $WORKSPACE/eden/bin/notify-github-commit-status.py failure</command>
+        <configuredLocalRules/>
+      </buildStep>
+      <runner class="org.jenkins_ci.plugins.run_condition.BuildStepRunner$Fail" plugin="run-condition@1.5"/>
+    </org.jenkinsci.plugins.conditionalbuildstep.singlestep.SingleConditionalBuilder>
+  </builders>
+  <publishers>
+    <xunit plugin="xunit@3.1.0">
+      <types>
+        <JUnitType>
+          <pattern>**/build/tests/pytest*.xml,**/build/cpptests/*.xml</pattern>
+          <excludesPattern/>
+          <skipNoTestFiles>true</skipNoTestFiles>
+          <failIfNotNew>false</failIfNotNew>
+          <deleteOutputFiles>true</deleteOutputFiles>
+          <stopProcessingIfError>true</stopProcessingIfError>
+        </JUnitType>
+      </types>
+      <thresholds>
+        <org.jenkinsci.plugins.xunit.threshold.FailedThreshold>
+          <unstableThreshold>0</unstableThreshold>
+          <unstableNewThreshold>0</unstableNewThreshold>
+        </org.jenkinsci.plugins.xunit.threshold.FailedThreshold>
+      </thresholds>
+      <thresholdMode>1</thresholdMode>
+      <extraConfiguration>
+        <testTimeMargin>3000</testTimeMargin>
+        <sleepTime>10</sleepTime>
+        <reduceLog>true</reduceLog>
+        <followSymlink>true</followSymlink>
+        <skipPublishingChecks>true</skipPublishingChecks>
+        <checksName/>
+      </extraConfiguration>
+      <testDataPublishers class="empty-set"/>
+    </xunit>
+    <org.jenkinsci.plugins.stashNotifier.StashNotifier plugin="stashNotifier@1.28">
+      <stashServerBaseUrl/>
+      <credentialsId/>
+      <ignoreUnverifiedSSLPeer>false</ignoreUnverifiedSSLPeer>
+      <commitSha1/>
+      <buildName/>
+      <includeBuildNumberInKey>false</includeBuildNumberInKey>
+      <projectKey/>
+      <prependParentProjectKey>false</prependParentProjectKey>
+      <disableInprogressNotification>false</disableInprogressNotification>
+      <considerUnstableAsSuccess>false</considerUnstableAsSuccess>
+      <globalConfig>
+        <adminAddress>bugreport@esss.co</adminAddress>
+        <jenkinsUrl>https://eden.esss.co/jenkins/</jenkinsUrl>
+      </globalConfig>
+    </org.jenkinsci.plugins.stashNotifier.StashNotifier>
+  </publishers>
+  <buildWrappers>
+    <hudson.plugins.ws__cleanup.PreBuildCleanup plugin="ws-cleanup@0.42">
+      <patterns>
+        <hudson.plugins.ws__cleanup.Pattern>
+          <pattern>**/build/tests/pytest*.xml</pattern>
+          <type>INCLUDE</type>
+        </hudson.plugins.ws__cleanup.Pattern>
+        <hudson.plugins.ws__cleanup.Pattern>
+          <pattern>**/build/cpptests/*.xml</pattern>
+          <type>INCLUDE</type>
+        </hudson.plugins.ws__cleanup.Pattern>
+      </patterns>
+      <deleteDirs>false</deleteDirs>
+      <cleanupParameter/>
+      <externalDelete/>
+      <disableDeferredWipeout>false</disableDeferredWipeout>
+    </hudson.plugins.ws__cleanup.PreBuildCleanup>
+    <hudson.plugins.timestamper.TimestamperBuildWrapper plugin="timestamper@1.18"/>
+    <hudson.plugins.ansicolor.AnsiColorBuildWrapper plugin="ansicolor@1.0.1">
+      <colorMapName>xterm</colorMapName>
+    </hudson.plugins.ansicolor.AnsiColorBuildWrapper>
+  </buildWrappers>
+</project>

--- a/tests/test_jenkins_to_github_notify/job-single-repo.xml
+++ b/tests/test_jenkins_to_github_notify/job-single-repo.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?><project>
+  <description>&lt;!-- Managed by Job's Done --&gt;</description>
+  <keepDependencies>false</keepDependencies>
+  <logRotator>
+    <daysToKeep>7</daysToKeep>
+    <numToKeep>-1</numToKeep>
+    <artifactDaysToKeep>-1</artifactDaysToKeep>
+    <artifactNumToKeep>-1</artifactNumToKeep>
+  </logRotator>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <concurrentBuild>false</concurrentBuild>
+  <canRoam>false</canRoam>
+  <scm class="hudson.plugins.git.GitSCM">
+    <configVersion>2</configVersion>
+    <relativeTargetDir>eden</relativeTargetDir>
+    <userRemoteConfigs>
+      <hudson.plugins.git.UserRemoteConfig>
+        <url>ssh://git@eden.fln.esss.com.br:7999/esss/eden.git</url>
+      </hudson.plugins.git.UserRemoteConfig>
+    </userRemoteConfigs>
+    <branches>
+      <hudson.plugins.git.BranchSpec>
+        <name>master</name>
+      </hudson.plugins.git.BranchSpec>
+    </branches>
+    <extensions>
+      <hudson.plugins.git.extensions.impl.LocalBranch>
+        <localBranch>master</localBranch>
+      </hudson.plugins.git.extensions.impl.LocalBranch>
+      <hudson.plugins.git.extensions.impl.CloneOption>
+        <noTags>true</noTags>
+        <reference>$WORKSPACE/../../Shared/ref_repos/eden</reference>
+      </hudson.plugins.git.extensions.impl.CloneOption>
+      <hudson.plugins.git.extensions.impl.CleanCheckout/>
+      <hudson.plugins.git.extensions.impl.GitLFSPull/>
+    </extensions>
+    <localBranch>master</localBranch>
+  </scm>
+  <assignedNode>newlinux</assignedNode>
+  <builders>
+    <hudson.tasks.Shell>
+      <command>export CONDA_PY=310
+cd eden
+source $WORKSPACE/eden/bin/setup_slave $WORKSPACE/eden/dev_environment.devenv.yml _eden-dev-py310
+conda list
+inv --list
+inv ci-build
+# NOTE: If the above call fails because eden couldn't bootstrap itself, you can try running
+# the tests directly with:
+# pytest -ra -l --junitxml=build/tests/pytests.xml --cov=source/python --cov-report=xml:build/tests/coverage.xml --color=yes --basetemp="$WORKSPACE/eden/tmp" -n auto source/python -o junit_family=xunit2
+inv publish-coverage
+</command>
+    </hudson.tasks.Shell>
+  </builders>
+  <buildWrappers>
+    <hudson.plugins.ansicolor.AnsiColorBuildWrapper plugin="ansicolor@0.4.2">
+      <colorMapName>xterm</colorMapName>
+    </hudson.plugins.ansicolor.AnsiColorBuildWrapper>
+    <hudson.plugins.ws__cleanup.PreBuildCleanup>
+      <patterns>
+        <hudson.plugins.ws__cleanup.Pattern>
+          <pattern>**/build/tests/pytest*.xml</pattern>
+          <type>INCLUDE</type>
+        </hudson.plugins.ws__cleanup.Pattern>
+      </patterns>
+    </hudson.plugins.ws__cleanup.PreBuildCleanup>
+    <hudson.plugins.build__timeout.BuildTimeoutWrapper>
+      <timeoutMinutes>20</timeoutMinutes>
+      <failBuild>true</failBuild>
+    </hudson.plugins.build__timeout.BuildTimeoutWrapper>
+    <hudson.plugins.timestamper.TimestamperBuildWrapper plugin="timestamper@1.7.4"/>
+  </buildWrappers>
+  <triggers>
+    <hudson.triggers.TimerTrigger>
+      <spec># Run preferably after the daily provision jobs
+30 13 * * *
+</spec>
+    </hudson.triggers.TimerTrigger>
+    <hudson.triggers.SCMTrigger>
+      <spec>H 2-20/1 * * *
+</spec>
+    </hudson.triggers.SCMTrigger>
+  </triggers>
+  <displayName>[master] eden newlinux py310</displayName>
+  <publishers>
+    <xunit>
+      <thresholds>
+        <org.jenkinsci.plugins.xunit.threshold.FailedThreshold>
+          <unstableThreshold>0</unstableThreshold>
+          <unstableNewThreshold>0</unstableNewThreshold>
+        </org.jenkinsci.plugins.xunit.threshold.FailedThreshold>
+      </thresholds>
+      <thresholdMode>1</thresholdMode>
+      <tools>
+        <JUnitType>
+          <pattern>**/build/tests/pytest*.xml</pattern>
+          <skipNoTestFiles>true</skipNoTestFiles>
+          <failIfNotNew>false</failIfNotNew>
+          <deleteOutputFiles>true</deleteOutputFiles>
+          <stopProcessingIfError>true</stopProcessingIfError>
+        </JUnitType>
+      </tools>
+    </xunit>
+    <hudson.tasks.Mailer>
+      <recipients>dev-ci@esss.co</recipients>
+      <dontNotifyEveryUnstableBuild>true</dontNotifyEveryUnstableBuild>
+      <sendToIndividuals>false</sendToIndividuals>
+    </hudson.tasks.Mailer>
+  </publishers>
+</project>


### PR DESCRIPTION
A job that has just started for the first time (and other times too if it is running on a worker which has not executed before) will not provide any repository/commits information when we request its information.

In that case we fallback to parsing the configuration and requesting that information from GitHub.

cc @igortg 